### PR TITLE
Fixed an issue with the -dept parameter being to large for convertto-…

### DIFF
--- a/NitroConfigurationFunctions/NITROConfigurationFunctions.psm1
+++ b/NitroConfigurationFunctions/NITROConfigurationFunctions.psm1
@@ -274,7 +274,10 @@ Set-StrictMode -Version Latest
             $hashtablePayload = @{}
             $hashtablePayload."params" = @{"warning"=$warning;"onerror"=$OnErrorAction;<#"action"=$Action#>}
             $hashtablePayload.$ResourceType = $Payload
-            $jsonPayload = ConvertTo-Json $hashtablePayload -Depth ([int]::MaxValue)
+            #In recent versions of powershell the max value for the depth on convertto-json is 100
+            #int::maxvalue returned 2147483647 and the max value it can accept is 100.
+            $jsonPayload = ConvertTo-Json $hashtablePayload -Depth 100
+
             Write-Verbose "JSON Payload:`n$jsonPayload"
         }
 


### PR DESCRIPTION
Hi, Was using the module to test a few things and ran across an error when trying to use some of the commands with powershell version 5.1. When running the commands I would see the error 
**_ConvertTo-Json : The maximum depth allowed for serialization is 100._**

This seems to be related to newer version of powershell where the max value is 100 for the depth. Also added a few comments around the change to let everyone why the change was made.